### PR TITLE
add paste action doing unescape

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,10 @@
 			{
 				"command": "extension.xmlPaste",
 				"title": "XML Paste"
+			},
+			{
+				"command": "extension.xmlPasteUnescaped",
+				"title": "XML Paste Unescaped"
 			}
 		]
 	},

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,26 @@ function pasteEscapedXML() {
 	});
 }
 
+function pasteUnescapedEscapedXML() {
+	vscode.env.clipboard.readText().then((text) => {
+		const activeEditor = vscode.window.activeTextEditor;
+		if (activeEditor && activeEditor.selection && activeEditor.selection.active) {
+			activeEditor.edit((editor) => {
+				let content = text.replace(/\&amp\;/g, '&');
+				content = content.replace(/\&gt\;/g, '>');
+				content = content.replace(/\&lt\;/g, '<');
+				const selection = activeEditor.selection;
+				if (selection.end === selection.start) {
+					editor.insert(selection.active, content);
+				}
+				else {
+					editor.replace(selection, content);
+				}
+			});
+		}
+	});
+}
+
 export function activate(context: vscode.ExtensionContext) {
 
 	let disposable = vscode.commands.registerCommand('extension.xmlPaste', () => {


### PR DESCRIPTION
add action to do the opposite of escaping while paste: paste unescaped. This is useful in order to work with code fragments that now can be copied back and forth using escape/unescape while pasting.